### PR TITLE
Keep files out of the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "test": "mocha",
     "compile": "coffee -m -c -o lib src && coffee -m -c -o lib test && uglifyjs -c -m -- lib/fnuc.js >lib/fnuc.min.js"
   },
+  "files": [
+    "lib/fnuc.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:algesten/fnuc.git"


### PR DESCRIPTION
This PR excludes all but necessary files from the npm package.

Before:

```
$ npm install fnuc ramda
$ du -sh node_modules/*
7.7M    node_modules/fnuc
1.5M    node_modules/ramda
```

After:

```
$ du -sh node_modules/*
52K     node_modules/fnuc
1.5M    node_modules/ramda
```

7.7M is too much for such a small library.

```
$ tree node_modules/fnuc
node_modules/fnuc/
├── lib
│   └── fnuc.js
├── package.json
└── README.md

1 directory, 3 files
```
